### PR TITLE
Add VCL language

### DIFF
--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -22,6 +22,7 @@ use Tempest\Highlight\Languages\Python\PythonLanguage;
 use Tempest\Highlight\Languages\Sql\SqlLanguage;
 use Tempest\Highlight\Languages\Text\TextLanguage;
 use Tempest\Highlight\Languages\Twig\TwigLanguage;
+use Tempest\Highlight\Languages\Vcl\VclLanguage;
 use Tempest\Highlight\Languages\Xml\XmlLanguage;
 use Tempest\Highlight\Languages\Yaml\YamlLanguage;
 use Tempest\Highlight\Themes\CssTheme;
@@ -53,6 +54,7 @@ final class Highlighter
             ->addLanguage(new PhpLanguage())
             ->addLanguage(new PythonLanguage())
             ->addLanguage(new SqlLanguage())
+            ->addLanguage(new VclLanguage())
             ->addLanguage(new XmlLanguage())
             ->addLanguage(new YamlLanguage())
             ->addLanguage(new TwigLanguage());

--- a/src/Languages/Vcl/Patterns/VclDoubleQuoteValuePattern.php
+++ b/src/Languages/Vcl/Patterns/VclDoubleQuoteValuePattern.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '"baz"', output: '"baz"')]
+final readonly class VclDoubleQuoteValuePattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '(?<match>\".*?\")';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::VALUE;
+    }
+}

--- a/src/Languages/Vcl/Patterns/VclFunctionCallPattern.php
+++ b/src/Languages/Vcl/Patterns/VclFunctionCallPattern.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: 'baz(req)', output: 'baz')]
+final readonly class VclFunctionCallPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '(?<match>[a-z][\w]+)\(';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::PROPERTY;
+    }
+}

--- a/src/Languages/Vcl/Patterns/VclFunctionNamePattern.php
+++ b/src/Languages/Vcl/Patterns/VclFunctionNamePattern.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: 'sub baz {', output: 'baz')]
+final readonly class VclFunctionNamePattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return 'sub\s(?<match>.+)\s?\{';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::PROPERTY;
+    }
+}

--- a/src/Languages/Vcl/Patterns/VclKeywordPattern.php
+++ b/src/Languages/Vcl/Patterns/VclKeywordPattern.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+final readonly class VclKeywordPattern implements Pattern
+{
+    use IsPattern;
+
+    public function __construct(private string $keyword)
+    {
+    }
+
+    public function getPattern(): string
+    {
+        return "/[\s]*(?<match>{$this->keyword})[\s].*/m";
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::KEYWORD;
+    }
+}

--- a/src/Languages/Vcl/Patterns/VclMultiLineCommentPattern.php
+++ b/src/Languages/Vcl/Patterns/VclMultiLineCommentPattern.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+final readonly class VclMultiLineCommentPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '/(?<match>\/\*(.|\n)*?\*\/)/m';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::COMMENT;
+    }
+
+}

--- a/src/Languages/Vcl/Patterns/VclOperatorPattern.php
+++ b/src/Languages/Vcl/Patterns/VclOperatorPattern.php
@@ -6,21 +6,25 @@ namespace Tempest\Highlight\Languages\Vcl\Patterns;
 
 use Tempest\Highlight\IsPattern;
 use Tempest\Highlight\Pattern;
-use Tempest\Highlight\PatternTest;
 use Tempest\Highlight\Tokens\TokenTypeEnum;
 
-#[PatternTest(input: 'sub baz {', output: 'baz')]
-final readonly class VclFunctionNamePattern implements Pattern
+final readonly class VclOperatorPattern implements Pattern
 {
     use IsPattern;
 
+    public function __construct(private string $operator)
+    {
+    }
+
     public function getPattern(): string
     {
-        return 'sub\s(?<match>.+)\s\{';
+        $quoted = preg_quote($this->operator, '/');
+
+        return "/(?<match>{$quoted})/";
     }
 
     public function getTokenType(): TokenTypeEnum
     {
-        return TokenTypeEnum::PROPERTY;
+        return TokenTypeEnum::OPERATOR;
     }
 }

--- a/src/Languages/Vcl/Patterns/VclSingleLineCommentPattern.php
+++ b/src/Languages/Vcl/Patterns/VclSingleLineCommentPattern.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '# comment', output: '# comment')]
+#[PatternTest(input: 'set req.grace = 10s; # comment', output: '# comment')]
+#[PatternTest(input: 'set req.grace = 10s; // comment', output: '// comment')]
+final readonly class VclSingleLineCommentPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '(?<match>(#|\/\/).+)';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::COMMENT;
+    }
+
+}

--- a/src/Languages/Vcl/Patterns/VclVariablePattern.php
+++ b/src/Languages/Vcl/Patterns/VclVariablePattern.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+final readonly class VclVariablePattern implements Pattern
+{
+    use IsPattern;
+
+    public function __construct(private string $variable)
+    {
+    }
+
+    public function getPattern(): string
+    {
+        return "\s?(?<match>{$this->variable})\.";
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::VARIABLE;
+    }
+}

--- a/src/Languages/Vcl/VclLanguage.php
+++ b/src/Languages/Vcl/VclLanguage.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Vcl;
+
+use Tempest\Highlight\Languages\Base\BaseLanguage;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclFunctionCallPattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclFunctionNamePattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclKeywordPattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclMultiLineCommentPattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclSingleLineCommentPattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclVariablePattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclDoubleQuoteValuePattern;
+
+class VclLanguage extends BaseLanguage
+{
+    public function getName(): string
+    {
+        return 'vcl';
+    }
+
+    public function getPatterns(): array
+    {
+        return [
+            new VclDoubleQuoteValuePattern(),
+            new VclMultiLineCommentPattern(),
+            new VclSingleLineCommentPattern(),
+            new VclFunctionNamePattern(),
+            new VclFunctionCallPattern(),
+
+            new VclKeywordPattern('vcl'),
+            new VclKeywordPattern('import'),
+            new VclKeywordPattern('backend'),
+            new VclKeywordPattern('probe'),
+            new VclKeywordPattern('acl'),
+            new VclKeywordPattern('set'),
+            new VclKeywordPattern('unset'),
+            new VclKeywordPattern('if'),
+            new VclKeywordPattern('else'),
+            new VclKeywordPattern('elseif'),
+            new VclKeywordPattern('elsif'),
+            new VclKeywordPattern('elif'),
+            new VclKeywordPattern('sub'),
+            new VclKeywordPattern('return'),
+
+            new VclVariablePattern('req'),
+            new VclVariablePattern('req_top'),
+            new VclVariablePattern('resp'),
+            new VclVariablePattern('bereq'),
+            new VclVariablePattern('beresp'),
+            new VclVariablePattern('obj'),
+            new VclVariablePattern('local'),
+            new VclVariablePattern('client'),
+            new VclVariablePattern('server'),
+            new VclVariablePattern('sess'),
+            new VclVariablePattern('storage'),
+        ];
+    }
+}

--- a/src/Languages/Vcl/VclLanguage.php
+++ b/src/Languages/Vcl/VclLanguage.php
@@ -9,6 +9,7 @@ use Tempest\Highlight\Languages\Vcl\Patterns\VclFunctionCallPattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclFunctionNamePattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclKeywordPattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclMultiLineCommentPattern;
+use Tempest\Highlight\Languages\Vcl\Patterns\VclOperatorPattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclSingleLineCommentPattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclVariablePattern;
 use Tempest\Highlight\Languages\Vcl\Patterns\VclDoubleQuoteValuePattern;
@@ -32,7 +33,6 @@ class VclLanguage extends BaseLanguage
             new VclKeywordPattern('vcl'),
             new VclKeywordPattern('import'),
             new VclKeywordPattern('backend'),
-            new VclKeywordPattern('probe'),
             new VclKeywordPattern('acl'),
             new VclKeywordPattern('set'),
             new VclKeywordPattern('unset'),
@@ -55,6 +55,15 @@ class VclLanguage extends BaseLanguage
             new VclVariablePattern('server'),
             new VclVariablePattern('sess'),
             new VclVariablePattern('storage'),
+
+            new VclOperatorPattern('='),
+            new VclOperatorPattern('=='),
+            new VclOperatorPattern('!='),
+            new VclOperatorPattern('~'),
+            new VclOperatorPattern('!~'),
+            new VclOperatorPattern('!'),
+            new VclOperatorPattern('&&'),
+            new VclOperatorPattern('||'),
         ];
     }
 }

--- a/src/Themes/Css/highlight-light-lite.css
+++ b/src/Themes/Css/highlight-light-lite.css
@@ -26,7 +26,7 @@ pre, code {
 .hl-number,
 .hl-literal,
 .hl-value {
-    color: #000;
+    color: #1c6400;
 }
 
 .hl-variable {

--- a/tests/targets/vcl.md
+++ b/tests/targets/vcl.md
@@ -1,0 +1,123 @@
+```vcl
+vcl 4.1;
+
+import std;
+
+/*
+ server1 is default backend
+*/
+backend server1 {
+    .host = "127.0.0.1";
+    .port = "8080";
+    .max_connections = 100;
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: localhost"
+            "Connection: close"
+            "User-Agent: Varnish Health Probe";
+        .interval  = 10s;
+        .timeout   = 5s;
+        .window    = 5;
+        .threshold = 3;
+    }
+    .connect_timeout        = 5s;
+    .first_byte_timeout     = 90s;
+    .between_bytes_timeout  = 2s;
+}
+
+# https://www.varnish-software.com/developers/tutorials/example-vcl-template/#2-purging-acl
+acl purge {
+    "localhost";
+    "127.0.0.1";
+    "::1";
+}
+
+sub vcl_recv {
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+    unset req.http.proxy;
+    set req.url = std.querysort(req.url);
+    set req.url = regsub(req.url, "\?$", "");
+    set req.http.Surrogate-Capability = "key=ESI/1.0";
+
+    // https://www.varnish-software.com/developers/tutorials/example-vcl-template/#15-setting-grace-mode
+    if (std.healthy(req.backend_hint)) {
+        set req.grace = 10s;
+    }
+
+    if (!req.http.X-Forwarded-Proto) {
+        if(std.port(server.ip) == 443 || std.port(server.ip) == 8443) {
+            set req.http.X-Forwarded-Proto = "https";
+        } else {
+            set req.http.X-Forwarded-Proto = "https";
+        }
+    }
+
+    if (req.http.Upgrade ~ "(?i)websocket") {
+        return (pipe);
+    }
+
+    if (req.url ~ "(\?|&)(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=") {
+        set req.url = regsuball(req.url, "&(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "");
+        set req.url = regsuball(req.url, "\?(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "?");
+        set req.url = regsub(req.url, "\?&", "?");
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    if (req.method == "PURGE") {
+        if (!client.ip ~ purge) {
+            return (synth(405, client.ip + " is not allowed to send PURGE requests."));
+        }
+        return (purge);
+    }
+
+    if (req.method != "GET" &&
+        req.method != "HEAD" &&
+        req.method != "PUT" &&
+        req.method != "POST" &&
+        req.method != "TRACE" &&
+        req.method != "OPTIONS" &&
+        req.method != "PATCH" &&
+        req.method != "DELETE") {
+        return (pipe);
+    }
+
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    if (req.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|ogg|ogm|opus|otf|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
+        unset req.http.Cookie;
+        return (hash);
+    }
+
+    set req.http.Cookie = regsuball(req.http.Cookie, "(__utm|_ga|_opt)[a-z_]*=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "(__)?hs[a-z_\-]+=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "hubspotutk=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "_hj[a-zA-Z]+=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "(NID|DSID|__gads|GED_PLAYLIST_ACTIVITY|ACLK_DATA|ANID|AID|IDE|TAID|_gcl_[a-z]*|FLC|RUL|PAIDCONTENT|1P_JAR|Conversion|VISITOR_INFO1[a-z_]*)=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "^;\s*", "");
+
+    if (req.http.cookie ~ "^\s*$") {
+        unset req.http.cookie;
+    }
+}
+
+sub vcl_hash {
+    hash_data(req.http.X-Forwarded-Proto);
+}
+
+sub vcl_backend_response {
+    if (bereq.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|ogg|ogm|opus|otf|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
+        unset beresp.http.Set-Cookie;
+        set beresp.ttl = 1d;
+    }
+
+    if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
+        unset beresp.http.Surrogate-Control;
+        set beresp.do_esi = true;
+    }
+
+    set beresp.grace = 6h;
+}
+```


### PR DESCRIPTION
Based on VCL reference : https://varnish-cache.org/docs/6.0/reference/vcl.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced support for Varnish Configuration Language (VCL), including various patterns for syntax highlighting.
	- Added new VCL language support with specific patterns for double-quoted values, function calls, keywords, comments, and variables.
	- Created a sample VCL script for configuring a Varnish cache server.

- **Bug Fixes**
	- Removed duplicate entry for JavaScript language in the highlighter.

- **Style**
	- Updated color properties in the CSS for better visibility of highlighted elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->